### PR TITLE
Add dynamic references and fix group membership issues in Microsoft Graph function

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,13 @@ spec:
 |-------|------|-------------|
 | `queryType` | string | Required. Type of query to perform. Valid values: `UserValidation`, `GroupMembership`, `GroupObjectIDs`, `ServicePrincipalDetails` |
 | `users` | []string | List of user principal names (email IDs) for user validation |
+| `usersRef` | string | Reference to resolve a list of user names from `spec`, `status` or `context` (e.g., `spec.userAccess.emails`) |
 | `group` | string | Single group name for group membership queries |
+| `groupRef` | string | Reference to resolve a single group name from `spec`, `status` or `context` (e.g., `spec.groupConfig.name`) |
 | `groups` | []string | List of group names for group object ID queries |
+| `groupsRef` | string | Reference to resolve a list of group names from `spec`, `status` or `context` (e.g., `spec.groupConfig.names`) |
 | `servicePrincipals` | []string | List of service principal names |
+| `servicePrincipalsRef` | string | Reference to resolve a list of service principal names from `spec`, `status` or `context` (e.g., `spec.servicePrincipalConfig.names`) |
 | `target` | string | Required. Where to store the query results. Can be `status.<field>` or `context.<field>` |
 | `skipQueryWhenTargetHasData` | bool | Optional. When true, will skip the query if the target already has data |
 
@@ -211,6 +215,50 @@ target: "context.results"
 
 # Store in Environment
 target: "context.[apiextensions.crossplane.io/environment].results"
+```
+
+## Using Reference Fields
+
+You can reference values from XR spec, status, or context instead of hardcoding them:
+
+### Using groupRef from spec
+
+```yaml
+apiVersion: msgraph.fn.crossplane.io/v1alpha1
+kind: Input
+queryType: GroupMembership
+groupRef: "spec.groupConfig.name"  # Get group name from XR spec
+target: "status.groupMembers"
+```
+
+### Using groupsRef from spec
+
+```yaml
+apiVersion: msgraph.fn.crossplane.io/v1alpha1
+kind: Input
+queryType: GroupObjectIDs
+groupsRef: "spec.groupConfig.names"  # Get group names from XR spec
+target: "status.groupObjectIDs"
+```
+
+### Using usersRef from spec
+
+```yaml
+apiVersion: msgraph.fn.crossplane.io/v1alpha1
+kind: Input
+queryType: UserValidation
+usersRef: "spec.userAccess.emails"  # Get user emails from XR spec
+target: "status.validatedUsers"
+```
+
+### Using servicePrincipalsRef from spec
+
+```yaml
+apiVersion: msgraph.fn.crossplane.io/v1alpha1
+kind: Input
+queryType: ServicePrincipalDetails
+servicePrincipalsRef: "spec.servicePrincipalConfig.names"  # Get service principal names from XR spec
+target: "status.servicePrincipals"
 ```
 
 ## References

--- a/example/README.md
+++ b/example/README.md
@@ -68,6 +68,16 @@ Get object IDs for specified Azure AD groups:
 crossplane render xr.yaml group-objectids-example.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
 ```
 
+Dynamic `groupsRef` variations:
+
+```shell
+crossplane render xr.yaml group-objectids-example-status-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
+```
+
+```shell
+crossplane render xr.yaml group-objectids-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
+```
+
 ### 4. Service Principal Details
 
 Get details of specified service principals:

--- a/example/README.md
+++ b/example/README.md
@@ -52,6 +52,10 @@ crossplane render xr.yaml user-validation-example-status-ref.yaml functions.yaml
 crossplane render xr.yaml user-validation-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
 ```
 
+```shell
+crossplane render xr.yaml user-validation-example-spec-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
+```
+
 ### 2. Group Membership
 
 Get all members of a specified Azure AD group:
@@ -68,6 +72,10 @@ crossplane render xr.yaml group-membership-example-status-ref.yaml functions.yam
 
 ```shell
 crossplane render xr.yaml group-membership-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
+```
+
+```shell
+crossplane render xr.yaml group-membership-example-spec-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
 ```
 
 ### 3. Group Object IDs
@@ -88,6 +96,10 @@ crossplane render xr.yaml group-objectids-example-status-ref.yaml functions.yaml
 crossplane render xr.yaml group-objectids-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
 ```
 
+```shell
+crossplane render xr.yaml group-objectids-example-spec-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
+```
+
 ### 4. Service Principal Details
 
 Get details of specified service principals:
@@ -104,4 +116,8 @@ crossplane render xr.yaml service-principal-example-status-ref.yaml functions.ya
 
 ```shell
 crossplane render xr.yaml service-principal-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
+```
+
+```shell
+crossplane render xr.yaml service-principal-example-spec-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -42,6 +42,16 @@ Validate if specified Azure AD users exist:
 crossplane render xr.yaml user-validation-example.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
 ```
 
+Dynamic `usersRef` variations:
+
+```shell
+crossplane render xr.yaml user-validation-example-status-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
+```
+
+```shell
+crossplane render xr.yaml user-validation-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
+```
+
 ### 2. Group Membership
 
 Get all members of a specified Azure AD group:

--- a/example/README.md
+++ b/example/README.md
@@ -95,3 +95,13 @@ Get details of specified service principals:
 ```shell
 crossplane render xr.yaml service-principal-example.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
 ```
+
+Dynamic `servicePrinicpalsRef` variations:
+
+```shell
+crossplane render xr.yaml service-principal-example-status-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
+```
+
+```shell
+crossplane render xr.yaml service-principal-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
+```

--- a/example/README.md
+++ b/example/README.md
@@ -50,6 +50,16 @@ Get all members of a specified Azure AD group:
 crossplane render xr.yaml group-membership-example.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
 ```
 
+Dynamic `groupRef` variations:
+
+```shell
+crossplane render xr.yaml group-membership-example-status-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
+```
+
+```shell
+crossplane render xr.yaml group-membership-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
+```
+
 ### 3. Group Object IDs
 
 Get object IDs for specified Azure AD groups:

--- a/example/definition.yaml
+++ b/example/definition.yaml
@@ -23,6 +23,36 @@ spec:
               queryResourceType:
                 description: resource type for az resource query construction
                 type: string
+              groupConfig:
+                description: Configuration for group references
+                type: object
+                properties:
+                  name:
+                    description: Name of a single group to reference with groupRef
+                    type: string
+                  names:
+                    description: List of group names to reference with groupsRef
+                    type: array
+                    items:
+                      type: string
+              userAccess:
+                description: Configuration for user references
+                type: object
+                properties:
+                  emails:
+                    description: List of user emails to reference with usersRef
+                    type: array
+                    items:
+                      type: string
+              servicePrincipalConfig:
+                description: Configuration for service principal references
+                type: object
+                properties:
+                  names:
+                    description: List of service principal names to reference with servicePrincipalsRef
+                    type: array
+                    items:
+                      type: string
           status:
             description: XRStatus defines the observed state of XR.
             type: object

--- a/example/definition.yaml
+++ b/example/definition.yaml
@@ -27,15 +27,30 @@ spec:
             description: XRStatus defines the observed state of XR.
             type: object
             properties:
-              azResourceGraphQueryResult:
-                description: Freeform field containing query results from function-azresourcegraph
+              groupMembers:
+                description: Freeform field containing query results from function-msgraph
                 type: array
                 items:
                   type: object
                 x-kubernetes-preserve-unknown-fields: true
-              azResourceGraphQuery:
-                description: Freeform field containing query results from function-azresourcegraph
-                type: string
+              validatedUsers:
+                description: Freeform field containing query results from function-msgraph
+                type: array
+                items:
+                  type: object
+                x-kubernetes-preserve-unknown-fields: true
+              groupObjectIDs:
+                description: Freeform field containing query results from function-msgraph
+                type: array
+                items:
+                  type: object
+                x-kubernetes-preserve-unknown-fields: true
+              servicePrincipals:
+                description: Freeform field containing query results from function-msgraph
+                type: array
+                items:
+                  type: object
+                x-kubernetes-preserve-unknown-fields: true
         required:
         - spec
         type: object

--- a/example/envconfig.yaml
+++ b/example/envconfig.yaml
@@ -9,3 +9,5 @@ data:
     - test-fn-msgraph
   users:
     - yury@upbound.io
+  servicePrincipalNames:
+    - yury-upbound-oidc-provider

--- a/example/envconfig.yaml
+++ b/example/envconfig.yaml
@@ -7,3 +7,5 @@ data:
     name: test-fn-msgraph
   groups:
     - test-fn-msgraph
+  users:
+    - yury@upbound.io

--- a/example/envconfig.yaml
+++ b/example/envconfig.yaml
@@ -5,3 +5,5 @@ metadata:
 data:
   group:
     name: test-fn-msgraph
+  groups:
+    - test-fn-msgraph

--- a/example/envconfig.yaml
+++ b/example/envconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: EnvironmentConfig
+metadata:
+  name: example-config
+data:
+  group:
+    name: test-fn-msgraph

--- a/example/functions.yaml
+++ b/example/functions.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   package: xpkg.upbound.io/upbound/function-msgraph:v0.1.0
 ---
----
 apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:

--- a/example/functions.yaml
+++ b/example/functions.yaml
@@ -8,3 +8,11 @@ metadata:
     render.crossplane.io/runtime: Development
 spec:
   package: xpkg.upbound.io/upbound/function-msgraph:v0.1.0
+---
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: crossplane-contrib-function-environment-configs
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.2.0

--- a/example/group-membership-example-context-ref.yaml
+++ b/example/group-membership-example-context-ref.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: group-membership-example
+    # Important: This function requires an Azure AD app registration with Microsoft Graph API permissions:
+    # - Group.Read.All
+    # - Directory.Read.All
+    # - User.Read.All (if groups contain users)
+    # - Application.Read.All (if groups contain service principals)
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: environmentConfigs
+      functionRef:
+        name: crossplane-contrib-function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: example-config
+    - step: get-group-members
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: GroupMembership
+        groupRef: context.[apiextensions.crossplane.io/environment].group.name
+        # The function will automatically select standard fields:
+        # - id, displayName, mail, userPrincipalName, appId, description
+        target: "status.groupMembers"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/group-membership-example-spec-ref.yaml
+++ b/example/group-membership-example-spec-ref.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: group-membership-example-spec-ref
+  annotations:
+    # Important: This function requires an Azure AD app registration with Microsoft Graph API permissions:
+    # - Group.Read.All
+    # - Directory.Read.All
+    # - User.Read.All (if groups contain users)
+    # - Application.Read.All (if groups contain service principals)
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: get-group-members
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: GroupMembership
+        # Using spec reference to get group name
+        groupRef: "spec.groupConfig.name"
+        # The function will automatically select standard fields:
+        # - id, displayName, mail, userPrincipalName, appId, description
+        target: "status.groupMembers"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/group-membership-example-status-ref.yaml
+++ b/example/group-membership-example-status-ref.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: group-membership-example
+  annotations:
+    # Important: This function requires an Azure AD app registration with Microsoft Graph API permissions:
+    # - Group.Read.All
+    # - Directory.Read.All
+    # - User.Read.All (if groups contain users)
+    # - Application.Read.All (if groups contain service principals)
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: get-group-members
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: GroupMembership
+        groupRef: status.group.name
+        # The function will automatically select standard fields:
+        # - id, displayName, mail, userPrincipalName, appId, description
+        target: "status.groupMembers"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/group-membership-example.yaml
+++ b/example/group-membership-example.yaml
@@ -21,7 +21,7 @@ spec:
         apiVersion: msgraph.fn.crossplane.io/v1alpha1
         kind: Input
         queryType: GroupMembership
-        group: "All Company"
+        group: test-fn-msgraph
         # The function will automatically select standard fields:
         # - id, displayName, mail, userPrincipalName, appId, description
         target: "status.groupMembers"

--- a/example/group-objectids-example-context-ref.yaml
+++ b/example/group-objectids-example-context-ref.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: group-membership-example-context-ref
+  name: group-objectids-example-context-ref
 spec:
   compositeTypeRef:
     apiVersion: example.crossplane.io/v1
@@ -19,17 +19,15 @@ spec:
             - type: Reference
               ref:
                 name: example-config
-    - step: get-group-members
+    - step: get-group-objectids
       functionRef:
         name: function-msgraph
       input:
         apiVersion: msgraph.fn.crossplane.io/v1alpha1
         kind: Input
-        queryType: GroupMembership
-        groupRef: context.[apiextensions.crossplane.io/environment].group.name
-        # The function will automatically select standard fields:
-        # - id, displayName, mail, userPrincipalName, appId, description
-        target: "status.groupMembers"
+        queryType: GroupObjectIDs
+        groupsRef: context.[apiextensions.crossplane.io/environment].groups
+        target: "status.groupObjectIDs"
         skipQueryWhenTargetHasData: true
       credentials:
         - name: azure-creds

--- a/example/group-objectids-example-spec-ref.yaml
+++ b/example/group-objectids-example-spec-ref.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: group-objectids-example-spec-ref
+  annotations:
+    # Important: This function requires an Azure AD app registration with Microsoft Graph API permissions:
+    # - Group.Read.All
+    # - Directory.Read.All
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: get-group-objectids
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: GroupObjectIDs
+        # Using spec reference to get group names
+        groupsRef: "spec.groupConfig.names"
+        target: "status.groupObjectIDs"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/group-objectids-example-status-ref.yaml
+++ b/example/group-objectids-example-status-ref.yaml
@@ -1,24 +1,26 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: group-membership-example-status-ref
+  name: group-objectids-example-status-ref
+  annotations:
+    # Important: This function requires an Azure AD app registration with Microsoft Graph API permissions:
+    # - Group.Read.All
+    # - Directory.Read.All
 spec:
   compositeTypeRef:
     apiVersion: example.crossplane.io/v1
     kind: XR
   mode: Pipeline
   pipeline:
-    - step: get-group-members
+    - step: get-group-objectids
       functionRef:
         name: function-msgraph
       input:
         apiVersion: msgraph.fn.crossplane.io/v1alpha1
         kind: Input
-        queryType: GroupMembership
-        groupRef: status.group.name
-        # The function will automatically select standard fields:
-        # - id, displayName, mail, userPrincipalName, appId, description
-        target: "status.groupMembers"
+        queryType: GroupObjectIDs
+        groupsRef: status.groups
+        target: "status.groupObjectIDs"
         skipQueryWhenTargetHasData: true
       credentials:
         - name: azure-creds

--- a/example/group-objectids-example.yaml
+++ b/example/group-objectids-example.yaml
@@ -23,6 +23,7 @@ spec:
           - "Developers"
           - "All Engineering"
           - "All Company"
+          - test-fn-msgraph
         target: "status.groupObjectIDs"
         skipQueryWhenTargetHasData: true
       credentials:

--- a/example/service-principal-example-context-ref.yaml
+++ b/example/service-principal-example-context-ref.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: service-principal-example-context-ref
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: environmentConfigs
+      functionRef:
+        name: crossplane-contrib-function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: example-config
+    - step: get-service-principal-details
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: ServicePrincipalDetails
+        servicePrincipalsRef: context.[apiextensions.crossplane.io/environment].servicePrincipalNames
+        target: "status.servicePrincipals"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/service-principal-example-spec-ref.yaml
+++ b/example/service-principal-example-spec-ref.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: service-principal-example-spec-ref
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: get-service-principal-details
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: ServicePrincipalDetails
+        # Using spec reference to get service principal names
+        servicePrincipalsRef: "spec.servicePrincipalConfig.names"
+        target: "status.servicePrincipalDetails"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/service-principal-example-status-ref.yaml
+++ b/example/service-principal-example-status-ref.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: service-principal-example-status-ref
+  annotations:
+    # Important: This function requires an Azure AD app registration with Microsoft Graph API permissions:
+    # - Application.Read.All
+    # - Directory.Read.All
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: get-service-principal-details
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: ServicePrincipalDetails
+        servicePrincipalsRef: status.servicePrincipalNames
+        target: "status.servicePrincipals"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/service-principal-example.yaml
+++ b/example/service-principal-example.yaml
@@ -18,7 +18,7 @@ spec:
         servicePrincipals:
           - "MyServiceApp"
           - "ApiConnector"
-          - "dare-oidc-provider"
+          - "yury-upbound-oidc-provider"
         target: "status.servicePrincipalDetails"
         skipQueryWhenTargetHasData: true
       credentials:

--- a/example/user-validation-example-context-ref.yaml
+++ b/example/user-validation-example-context-ref.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: user-validation-example-context-ref
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: environmentConfigs
+      functionRef:
+        name: crossplane-contrib-function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: example-config
+    - step: validate-users
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: UserValidation
+        usersRef: context.[apiextensions.crossplane.io/environment].users
+        target: "status.validatedUsers"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/user-validation-example-spec-ref.yaml
+++ b/example/user-validation-example-spec-ref.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: user-validation-example-spec-ref
+# Important: This function example requires an Azure AD app registration with Microsoft Graph API permissions:
+# - User.Read.All
+# - Directory.Read.All
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: validate-user
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: UserValidation
+        # Using spec reference to get user emails
+        usersRef: "spec.userAccess.emails"
+        target: "status.validatedUsers"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/user-validation-example-status-ref.yaml
+++ b/example/user-validation-example-status-ref.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: user-validation-example-status-ref
+  annotations:
+    # Important: This function requires an Azure AD app registration with Microsoft Graph API permissions:
+    # - User.Read.All
+    # - Directory.Read.All
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: validate-users
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: UserValidation
+        usersRef: status.users
+        target: "status.validatedUsers"
+        skipQueryWhenTargetHasData: true
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/xr.yaml
+++ b/example/xr.yaml
@@ -4,3 +4,6 @@ kind: XR
 metadata:
   name: example-xr
 spec: {}
+status:
+  group:
+    name: test-fn-msgraph

--- a/example/xr.yaml
+++ b/example/xr.yaml
@@ -7,3 +7,5 @@ spec: {}
 status:
   group:
     name: test-fn-msgraph
+  groups:
+    - test-fn-msgraph

--- a/example/xr.yaml
+++ b/example/xr.yaml
@@ -1,10 +1,36 @@
-# Replace this with your XR!
+# Example XR with both spec references and status fields
 apiVersion: example.crossplane.io/v1
 kind: XR
 metadata:
   name: example-xr
-spec: {}
+spec:
+  # Group config for group references
+  groupConfig:
+    # For single group reference (groupRef)
+    name: test-fn-msgraph
+    # For multiple group references (groupsRef)
+    names:
+      - "Developers"
+      - "All Engineering"
+      - "All Company"
+      - "test-fn-msgraph"
+  # User access config for user references
+  userAccess:
+    # For user validation (usersRef)
+    emails:
+      - "admin@example.onmicrosoft.com"
+      - "user@example.onmicrosoft.com"
+      - "yury@upbound.io"
+  # Service principal config for service principal references
+  servicePrincipalConfig:
+    # For service principal details (servicePrincipalsRef)
+    names:
+      - "MyServiceApp"
+      - "ApiConnector"
+      - "yury-upbound-oidc-provider"
+
 status:
+  # For testing status.field references
   group:
     name: test-fn-msgraph
   groups:

--- a/example/xr.yaml
+++ b/example/xr.yaml
@@ -9,3 +9,5 @@ status:
     name: test-fn-msgraph
   groups:
     - test-fn-msgraph
+  users:
+    - yury@upbound.io

--- a/example/xr.yaml
+++ b/example/xr.yaml
@@ -11,3 +11,5 @@ status:
     - test-fn-msgraph
   users:
     - yury@upbound.io
+  servicePrincipalNames:
+    - yury-upbound-oidc-provider

--- a/fn.go
+++ b/fn.go
@@ -397,39 +397,9 @@ func (g *GraphQuery) fetchGroupMembers(ctx context.Context, client *msgraphsdk.G
 		members = group.GetMembers()
 	}
 
-	// Log what we get directly from the API response
+	// Log basic information about the membership
 	if g.log != nil {
-		// Log basic information about the response
-		g.log.Info("API Response Data (using $expand=members workaround)",
-			"groupID", groupID,
-			"groupName", groupName,
-			"memberCount", len(members))
-
-		// Log if we got members back
-		if len(members) > 0 {
-			g.log.Info(fmt.Sprintf("Found %d members in group %s", len(members), groupName))
-
-			// Log each member's raw data
-			for i, member := range members {
-				if i >= 5 {
-					// Limit logging to first 5 members
-					break
-				}
-
-				memberID := member.GetId()
-				additionalData := member.GetAdditionalData()
-				memberType := fmt.Sprintf("%T", member)
-
-				// Try to marshal this member's additional data
-				rawData, err := json.MarshalIndent(additionalData, "", "  ")
-				if err == nil {
-					g.log.Info(fmt.Sprintf("Member %d (ID: %s, Type: %s)", i, *memberID, memberType))
-					g.log.Info(string(rawData))
-				}
-			}
-		} else {
-			g.log.Info("No members found in the group using $expand method")
-		}
+		g.log.Debug("Retrieved group members", "groupName", groupName, "groupID", groupID, "memberCount", len(members))
 	}
 
 	return members, nil

--- a/fn_test.go
+++ b/fn_test.go
@@ -30,7 +30,7 @@ func strPtr(s string) *string {
 	return &s
 }
 
-// TestResolveGroupsRef tests the functionality of resolving groupsRef from context or status
+// TestResolveGroupsRef tests the functionality of resolving groupsRef from context, status, or spec
 func TestResolveGroupsRef(t *testing.T) {
 	var (
 		xr    = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2}}`
@@ -196,6 +196,94 @@ func TestResolveGroupsRef(t *testing.T) {
 								"metadata": {
 									"name": "cool-xr"
 								},
+								"spec": {
+									"count": 2
+								},
+								"status": {
+									"groupObjectIDs": [
+										{
+											"id": "group-id-1",
+											"displayName": "Developers",
+											"description": "Development team"
+										},
+										{
+											"id": "group-id-2",
+											"displayName": "Operations",
+											"description": "Operations team"
+										},
+										{
+											"id": "group-id-3",
+											"displayName": "All Company",
+											"description": "All company group"
+										}
+									]
+								}}`),
+						},
+					},
+				},
+			},
+		},
+		"GroupsRefFromSpec": {
+			reason: "The Function should resolve groupsRef from XR spec",
+			args: args{
+				ctx: context.Background(),
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+						"kind": "Input",
+						"queryType": "GroupObjectIDs",
+						"groupsRef": "spec.groupConfig.groupNames",
+						"target": "status.groupObjectIDs"
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"spec": {
+									"groupConfig": {
+										"groupNames": ["Developers", "Operations", "All Company"]
+									}
+								}
+							}`),
+						},
+					},
+					Credentials: map[string]*fnv1.Credentials{
+						"azure-creds": {
+							Source: &fnv1.Credentials_CredentialData{CredentialData: creds},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Conditions: []*fnv1.Condition{
+						{
+							Type:   "FunctionSuccess",
+							Status: fnv1.Status_STATUS_CONDITION_TRUE,
+							Reason: "Success",
+							Target: fnv1.Target_TARGET_COMPOSITE_AND_CLAIM.Enum(),
+						},
+					},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_NORMAL,
+							Message:  `QueryType: "GroupObjectIDs"`,
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+						},
+					},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"spec": {
+									"groupConfig": {
+										"groupNames": ["Developers", "Operations", "All Company"]
+									}
+								},
 								"status": {
 									"groupObjectIDs": [
 										{
@@ -262,6 +350,9 @@ func TestResolveGroupsRef(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -328,7 +419,7 @@ func TestResolveGroupsRef(t *testing.T) {
 	}
 }
 
-// TestResolveGroupRef tests the functionality of resolving groupRef from context or status
+// TestResolveGroupRef tests the functionality of resolving groupRef from context, status, or spec
 func TestResolveGroupRef(t *testing.T) {
 	var (
 		xr    = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2}}`
@@ -500,6 +591,92 @@ func TestResolveGroupRef(t *testing.T) {
 								"metadata": {
 									"name": "cool-xr"
 								},
+								"spec": {
+									"count": 2
+								},
+								"status": {
+									"groupMembers": [
+										{
+											"id": "user-id-1",
+											"displayName": "Test User 1",
+											"mail": "user1@example.com",
+											"type": "user",
+											"userPrincipalName": "user1@example.com"
+										},
+										{
+											"id": "sp-id-1",
+											"displayName": "Test Service Principal",
+											"appId": "sp-app-id-1",
+											"type": "servicePrincipal"
+										}
+									]
+								}}`),
+						},
+					},
+				},
+			},
+		},
+		"GroupRefFromSpec": {
+			reason: "The Function should resolve groupRef from XR spec",
+			args: args{
+				ctx: context.Background(),
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+						"kind": "Input",
+						"queryType": "GroupMembership",
+						"groupRef": "spec.groupConfig.name",
+						"target": "status.groupMembers"
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"spec": {
+									"groupConfig": {
+										"name": "Developers"
+									}
+								}
+							}`),
+						},
+					},
+					Credentials: map[string]*fnv1.Credentials{
+						"azure-creds": {
+							Source: &fnv1.Credentials_CredentialData{CredentialData: creds},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Conditions: []*fnv1.Condition{
+						{
+							Type:   "FunctionSuccess",
+							Status: fnv1.Status_STATUS_CONDITION_TRUE,
+							Reason: "Success",
+							Target: fnv1.Target_TARGET_COMPOSITE_AND_CLAIM.Enum(),
+						},
+					},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_NORMAL,
+							Message:  `QueryType: "GroupMembership"`,
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+						},
+					},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"spec": {
+									"groupConfig": {
+										"name": "Developers"
+									}
+								},
 								"status": {
 									"groupMembers": [
 										{
@@ -564,6 +741,9 @@ func TestResolveGroupRef(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -619,7 +799,7 @@ func TestResolveGroupRef(t *testing.T) {
 	}
 }
 
-// TestResolveUsersRef tests the functionality of resolving usersRef from context or status
+// TestResolveUsersRef tests the functionality of resolving usersRef from context, status, or spec
 func TestResolveUsersRef(t *testing.T) {
 	var (
 		xr    = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2}}`
@@ -788,6 +968,97 @@ func TestResolveUsersRef(t *testing.T) {
 								"metadata": {
 									"name": "cool-xr"
 								},
+								"spec": {
+									"count": 2
+								},
+								"status": {
+									"validatedUsers": [
+										{
+											"id": "user-id-1",
+											"displayName": "User 1",
+											"userPrincipalName": "user1@example.com",
+											"mail": "user1@example.com"
+										},
+										{
+											"id": "user-id-2",
+											"displayName": "User 2",
+											"userPrincipalName": "user2@example.com",
+											"mail": "user2@example.com"
+										},
+										{
+											"id": "admin-id",
+											"displayName": "Admin User",
+											"userPrincipalName": "admin@example.onmicrosoft.com",
+											"mail": "admin@example.onmicrosoft.com"
+										}
+									]
+								}}`),
+						},
+					},
+				},
+			},
+		},
+		"UsersRefFromSpec": {
+			reason: "The Function should resolve usersRef from XR spec",
+			args: args{
+				ctx: context.Background(),
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+						"kind": "Input",
+						"queryType": "UserValidation",
+						"usersRef": "spec.userAccess.emails",
+						"target": "status.validatedUsers"
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"spec": {
+									"userAccess": {
+										"emails": ["user1@example.com", "user2@example.com", "admin@example.onmicrosoft.com"]
+									}
+								}
+							}`),
+						},
+					},
+					Credentials: map[string]*fnv1.Credentials{
+						"azure-creds": {
+							Source: &fnv1.Credentials_CredentialData{CredentialData: creds},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Conditions: []*fnv1.Condition{
+						{
+							Type:   "FunctionSuccess",
+							Status: fnv1.Status_STATUS_CONDITION_TRUE,
+							Reason: "Success",
+							Target: fnv1.Target_TARGET_COMPOSITE_AND_CLAIM.Enum(),
+						},
+					},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_NORMAL,
+							Message:  `QueryType: "UserValidation"`,
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+						},
+					},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"spec": {
+									"userAccess": {
+										"emails": ["user1@example.com", "user2@example.com", "admin@example.onmicrosoft.com"]
+									}
+								},
 								"status": {
 									"validatedUsers": [
 										{
@@ -857,6 +1128,9 @@ func TestResolveUsersRef(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -934,7 +1208,7 @@ func TestResolveUsersRef(t *testing.T) {
 	}
 }
 
-// TestResolveServicePrincipalsRef tests the functionality of resolving servicePrincipalsRef from context or status
+// TestResolveServicePrincipalsRef tests the functionality of resolving servicePrincipalsRef from context, status, or spec
 func TestResolveServicePrincipalsRef(t *testing.T) {
 	var (
 		xr    = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2}}`
@@ -1103,6 +1377,97 @@ func TestResolveServicePrincipalsRef(t *testing.T) {
 								"metadata": {
 									"name": "cool-xr"
 								},
+								"spec": {
+									"count": 2
+								},
+								"status": {
+									"servicePrincipals": [
+										{
+											"id": "sp-id-1",
+											"appId": "app-id-1",
+											"displayName": "MyServiceApp",
+											"description": "Service application"
+										},
+										{
+											"id": "sp-id-2",
+											"appId": "app-id-2",
+											"displayName": "ApiConnector",
+											"description": "API connector application"
+										},
+										{
+											"id": "sp-id-3",
+											"appId": "app-id-3",
+											"displayName": "yury-upbound-oidc-provider",
+											"description": "OIDC provider application"
+										}
+									]
+								}}`),
+						},
+					},
+				},
+			},
+		},
+		"ServicePrincipalsRefFromSpec": {
+			reason: "The Function should resolve servicePrincipalsRef from XR spec",
+			args: args{
+				ctx: context.Background(),
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+						"kind": "Input",
+						"queryType": "ServicePrincipalDetails",
+						"servicePrincipalsRef": "spec.servicePrincipalConfig.names",
+						"target": "status.servicePrincipals"
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"spec": {
+									"servicePrincipalConfig": {
+										"names": ["MyServiceApp", "ApiConnector", "yury-upbound-oidc-provider"]
+									}
+								}
+							}`),
+						},
+					},
+					Credentials: map[string]*fnv1.Credentials{
+						"azure-creds": {
+							Source: &fnv1.Credentials_CredentialData{CredentialData: creds},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Conditions: []*fnv1.Condition{
+						{
+							Type:   "FunctionSuccess",
+							Status: fnv1.Status_STATUS_CONDITION_TRUE,
+							Reason: "Success",
+							Target: fnv1.Target_TARGET_COMPOSITE_AND_CLAIM.Enum(),
+						},
+					},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_NORMAL,
+							Message:  `QueryType: "ServicePrincipalDetails"`,
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+						},
+					},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"spec": {
+									"servicePrincipalConfig": {
+										"names": ["MyServiceApp", "ApiConnector", "yury-upbound-oidc-provider"]
+									}
+								},
 								"status": {
 									"servicePrincipals": [
 										{
@@ -1172,6 +1537,9 @@ func TestResolveServicePrincipalsRef(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -1398,6 +1766,9 @@ func TestRunFunction(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -1456,6 +1827,9 @@ func TestRunFunction(t *testing.T) {
 								"metadata": {
 									"name": "cool-xr"
 								},
+								"spec": {
+									"count": 2
+								},
 								"status": {
 									"validatedUsers": [
 										{
@@ -1512,6 +1886,9 @@ func TestRunFunction(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -1569,6 +1946,9 @@ func TestRunFunction(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								},
 								"status": {
 									"groupMembers": [
@@ -1633,6 +2013,9 @@ func TestRunFunction(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -1690,6 +2073,9 @@ func TestRunFunction(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								},
 								"status": {
 									"groupObjectIDs": [
@@ -1751,6 +2137,9 @@ func TestRunFunction(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -1809,6 +2198,9 @@ func TestRunFunction(t *testing.T) {
 								"metadata": {
 									"name": "cool-xr"
 								},
+								"spec": {
+									"count": 2
+								},
 								"status": {
 									"servicePrincipals": [
 										{
@@ -1865,6 +2257,9 @@ func TestRunFunction(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},
@@ -2011,6 +2406,9 @@ func TestRunFunction(t *testing.T) {
 								"kind": "XR",
 								"metadata": {
 									"name": "cool-xr"
+								},
+								"spec": {
+									"count": 2
 								}
 							}`),
 						},

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -35,6 +35,11 @@ type Input struct {
 	// +optional
 	Group *string `json:"group,omitempty"`
 
+	// GroupRef is a reference to retrieve the group name (e.g., from status or context)
+	// Overrides Group field if used
+	// +optional
+	GroupRef *string `json:"groupRef,omitempty"`
+
 	// ServicePrincipals is a list of service principal names
 	// +optional
 	ServicePrincipals []*string `json:"servicePrincipals,omitempty"`

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -31,6 +31,11 @@ type Input struct {
 	// +optional
 	Groups []*string `json:"groups,omitempty"`
 
+	// GroupsRef is a reference to retrieve the group names (e.g., from status or context)
+	// Overrides Groups field if used
+	// +optional
+	GroupsRef *string `json:"groupsRef,omitempty"`
+
 	// Group is a single group name for group membership queries
 	// +optional
 	Group *string `json:"group,omitempty"`

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -27,6 +27,11 @@ type Input struct {
 	// +optional
 	Users []*string `json:"users,omitempty"`
 
+	// UsersRef is a reference to retrieve the user names (e.g., from status or context)
+	// Overrides Users field if used
+	// +optional
+	UsersRef *string `json:"usersRef,omitempty"`
+
 	// Groups is a list of group names for group object ID queries
 	// +optional
 	Groups []*string `json:"groups,omitempty"`

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -54,6 +54,11 @@ type Input struct {
 	// +optional
 	ServicePrincipals []*string `json:"servicePrincipals,omitempty"`
 
+	// ServicePrincipalsRef is a reference to retrieve the service principal names (e.g., from status or context)
+	// Overrides ServicePrincipals field if used
+	// +optional
+	ServicePrincipalsRef *string `json:"servicePrincipalsRef,omitempty"`
+
 	// Target where to store the Query Result
 	Target string `json:"target"`
 

--- a/input/v1beta1/zz_generated.deepcopy.go
+++ b/input/v1beta1/zz_generated.deepcopy.go
@@ -40,6 +40,11 @@ func (in *Input) DeepCopyInto(out *Input) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GroupRef != nil {
+		in, out := &in.GroupRef, &out.GroupRef
+		*out = new(string)
+		**out = **in
+	}
 	if in.ServicePrincipals != nil {
 		in, out := &in.ServicePrincipals, &out.ServicePrincipals
 		*out = make([]*string, len(*in))

--- a/input/v1beta1/zz_generated.deepcopy.go
+++ b/input/v1beta1/zz_generated.deepcopy.go
@@ -35,6 +35,11 @@ func (in *Input) DeepCopyInto(out *Input) {
 			}
 		}
 	}
+	if in.GroupsRef != nil {
+		in, out := &in.GroupsRef, &out.GroupsRef
+		*out = new(string)
+		**out = **in
+	}
 	if in.Group != nil {
 		in, out := &in.Group, &out.Group
 		*out = new(string)

--- a/input/v1beta1/zz_generated.deepcopy.go
+++ b/input/v1beta1/zz_generated.deepcopy.go
@@ -66,6 +66,11 @@ func (in *Input) DeepCopyInto(out *Input) {
 			}
 		}
 	}
+	if in.ServicePrincipalsRef != nil {
+		in, out := &in.ServicePrincipalsRef, &out.ServicePrincipalsRef
+		*out = new(string)
+		**out = **in
+	}
 	if in.SkipQueryWhenTargetHasData != nil {
 		in, out := &in.SkipQueryWhenTargetHasData, &out.SkipQueryWhenTargetHasData
 		*out = new(bool)

--- a/input/v1beta1/zz_generated.deepcopy.go
+++ b/input/v1beta1/zz_generated.deepcopy.go
@@ -24,6 +24,11 @@ func (in *Input) DeepCopyInto(out *Input) {
 			}
 		}
 	}
+	if in.UsersRef != nil {
+		in, out := &in.UsersRef, &out.UsersRef
+		*out = new(string)
+		**out = **in
+	}
 	if in.Groups != nil {
 		in, out := &in.Groups, &out.Groups
 		*out = make([]*string, len(*in))

--- a/package/input/msgraph.fn.crossplane.io_inputs.yaml
+++ b/package/input/msgraph.fn.crossplane.io_inputs.yaml
@@ -41,6 +41,11 @@ spec:
             items:
               type: string
             type: array
+          groupsRef:
+            description: |-
+              GroupsRef is a reference to retrieve the group names (e.g., from status or context)
+              Overrides Groups field if used
+            type: string
           kind:
             description: |-
               Kind is a string value representing the REST resource this object represents.

--- a/package/input/msgraph.fn.crossplane.io_inputs.yaml
+++ b/package/input/msgraph.fn.crossplane.io_inputs.yaml
@@ -31,6 +31,11 @@ spec:
           group:
             description: Group is a single group name for group membership queries
             type: string
+          groupRef:
+            description: |-
+              GroupRef is a reference to retrieve the group name (e.g., from status or context)
+              Overrides Group field if used
+            type: string
           groups:
             description: Groups is a list of group names for group object ID queries
             items:

--- a/package/input/msgraph.fn.crossplane.io_inputs.yaml
+++ b/package/input/msgraph.fn.crossplane.io_inputs.yaml
@@ -80,6 +80,11 @@ spec:
             items:
               type: string
             type: array
+          usersRef:
+            description: |-
+              UsersRef is a reference to retrieve the user names (e.g., from status or context)
+              Overrides Users field if used
+            type: string
         required:
         - queryType
         - target

--- a/package/input/msgraph.fn.crossplane.io_inputs.yaml
+++ b/package/input/msgraph.fn.crossplane.io_inputs.yaml
@@ -66,6 +66,11 @@ spec:
             items:
               type: string
             type: array
+          servicePrincipalsRef:
+            description: |-
+              ServicePrincipalsRef is a reference to retrieve the service principal names (e.g., from status or context)
+              Overrides ServicePrincipals field if used
+            type: string
           skipQueryWhenTargetHasData:
             description: |-
               SkipQueryWhenTargetHasData controls whether to skip the query when the target already has data


### PR DESCRIPTION
### Description of your changes

### Summary

  - Implemented dynamic reference capabilities for all query types, allowing references to values in XR spec, status or function context
  - Fixed group membership retrieval to properly include service principals using the expand workaround
  - Corrected user type identification in group membership results
  - Simplified debug API logging for better observability
  - Enhanced reference resolution to support spec fields using spec.* syntax
  - Improved propagation of spec from observed to desired XR
  - Added example compositions that demonstrate spec reference usage
  - Updated XR example to include spec fields that can be referenced
  - Refactored code to reduce complexity and improve maintainability
  - Added comprehensive tests for spec reference functionality

### Group Membership Fixes

  - Fixed issues with group membership queries not including service principals by implementing the recommended expand workaround in
   the Microsoft Graph API
  - Corrected user type identification by properly checking properties and interfaces
  - Improved extraction of service principal and user properties from API responses
  - Simplified logging to reduce noise while maintaining essential debug information

### Dynamic Reference Capabilities

  Added support for four new reference types:
  1. groupRef: References a single group name for GroupMembership queries
  2. groupsRef: References an array of group names for GroupObjectIDs queries
  3. usersRef: References an array of user names for UserValidation queries
  4. servicePrincipalsRef: References an array of service principal names for ServicePrincipalDetails queries

  These references allow users to dynamically source values from:
  - XR status fields (e.g., status.groups)
  - Function context, including environment variables (e.g., context.[apiextensions.crossplane.io/environment].users)

### Code Improvements

  - Refactored string array resolution to use common code paths
  - Modularized reference processing to reduce cyclomatic complexity
  - Added consistent error handling and logging
  - Created example compositions showing how to use each reference type
  - Implemented comprehensive test coverage for all reference types and edge cases

### Example Usage

```yaml
  # Dynamic references in function inputs
  queryType: GroupMembership
  groupRef: status.selectedGroup

  queryType: GroupObjectIDs
  groupsRef: context.[apiextensions.crossplane.io/environment].groups

  queryType: UserValidation
  usersRef: status.users

  queryType: ServicePrincipalDetails
  servicePrincipalsRef: context.[apiextensions.crossplane.io/environment].servicePrincipalNames
```

  All these improvements make the function more flexible and maintainable while fixing critical issues with group membership retrieval.

### Testing

 ```
crossplane render xr.yaml group-membership-example.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
---
apiVersion: example.crossplane.io/v1
kind: XR
metadata:
  name: example-xr
status:
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    reason: Available
    status: "True"
    type: Ready
  groupMembers:
  - displayName: Yury Tsarev
    id: <redacted>
    type: user
  - displayName: yury-upbound-oidc-provider
    id: <redacted>
    type: servicePrincipal
---
```
Both User and servicePrincipal group members are in the list 👍  

Dynamic `usersRef` variations:

```shell
crossplane render xr.yaml user-validation-example-status-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
```

```shell
crossplane render xr.yaml user-validation-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
```

Dynamic `groupRef` variations:

```shell
crossplane render xr.yaml group-membership-example-status-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
```

```shell
crossplane render xr.yaml group-membership-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
```

Dynamic `groupsRef` variations:

```shell
crossplane render xr.yaml group-objectids-example-status-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
```

```shell
crossplane render xr.yaml group-objectids-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
```

Dynamic `servicePrinicpalsRef` variations:

```shell
crossplane render xr.yaml service-principal-example-status-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
```

```shell
crossplane render xr.yaml service-principal-example-context-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc --extra-resources=envconfig.yaml
```

specRef tests

```shell
crossplane render xr.yaml user-validation-example-spec-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
crossplane render xr.yaml group-membership-example-spec-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
crossplane render xr.yaml group-objectids-example-spec-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
crossplane render xr.yaml service-principal-example-spec-ref.yaml functions.yaml --function-credentials=./secrets/azure-creds.yaml -rc
```

All examples are documented and working as expected.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
