### PR TITLE
Add 'additionalFields' Field to extract additional data from MSGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,45 @@ confirmed, `activeAccount: true` excludes the user.
 > (rather than `x-kubernetes-preserve-unknown-fields`) need to add
 > `accountEnabled` to that schema, otherwise the API server silently prunes it.
 
+### Additional Fields
+
+Use `additionalFields` to include extra Microsoft Graph attributes beyond the default set. Supported for all query types.
+
+| queryType | Default fields | Valid additional fields (examples) |
+|---|---|---|
+| `UserValidation` | `id`, `displayName`, `userPrincipalName`, `mail`, `accountEnabled` | `city`, `country`, `department`, `jobTitle`, `officeLocation`, `employeeType`, `usageLocation` |
+| `GroupObjectIDs` | `id`, `displayName`, `description` | `mailNickname`, `securityEnabled` |
+| `ServicePrincipalDetails` | `id`, `appId`, `displayName`, `description` | `servicePrincipalType`, `homepage` |
+| `GroupMembership` | `id`, `displayName`, `mail`, `userPrincipalName`, `appId` (plus `type`, derived by the function) | `department`, `jobTitle` (user members only) |
+
+> **Note:** Field names must match the Microsoft Graph API property name exactly (camelCase). Unknown field names are skipped with an `Info` log entry in the function pod. Fields that exist in Graph API but have no value for a given object are silently skipped (visible at `Debug` log level).
+
+```yaml
+apiVersion: msgraph.fn.crossplane.io/v1alpha1
+kind: Input
+queryType: UserValidation
+usersRef: "spec.owners"
+target: "status.validatedUsers"
+additionalFields:
+  - city
+  - department
+  - jobTitle
+```
+
+Result:
+
+```yaml
+status:
+  validatedUsers:
+    - id: 1bbbbbbb-...
+      displayName: Some Name
+      userPrincipalName: someName@example.com
+      mail: someName@example.com
+      city: Kyiv
+      department: Ops
+      jobTitle: Staff Engineer
+```
+
 ### Get Group Membership
 
 ```yaml
@@ -312,6 +351,7 @@ spec:
 | `queryInterval` | string | Optional. Minimum interval between queries as a Go duration string (e.g. `10m`, `1h`, `90s`). Skips querying Microsoft Graph until the interval has elapsed since the last successful query, independent of reconcile frequency. Only effective in Composition mode with a `status.` target. |
 | `failOnEmpty` | bool | Optional. When true, the function will fail if the `users`, `groups`, or `servicePrincipals` lists are empty, or if their respective reference fields are empty lists. |
 | `activeAccount` | bool | Optional. `UserValidation` only. When true, only users whose Entra ID `accountEnabled` attribute is true are stored at the target; disabled users, and users whose account state Graph does not report, are omitted. |
+| `additionalFields` | []string | Optional. Extra Microsoft Graph fields to include in results. Supported for all query types. Appended to the default field set for each type (see [Additional Fields](#additional-fields) section). |
 | `identity.type` | string | Optional. Type of identity credentials to use. Valid values: `AzureServicePrincipalCredentials`, `AzureWorkloadIdentityCredentials`. Default is `AzureServicePrincipalCredentials` |
 
 ## Result Targets

--- a/example/user-validation-additional-fields-example.yaml
+++ b/example/user-validation-additional-fields-example.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: user-validation-additional-fields-example
+# Demonstrates the additionalFields feature for UserValidation.
+# The extra fields are appended to the default set (id, displayName,
+# userPrincipalName, mail) and returned in status.validatedUsers.
+#
+# Required Azure AD app registration permissions:
+#   - User.Read.All
+#   - Directory.Read.All
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: validate-user-with-extra-fields
+      functionRef:
+        name: function-msgraph
+      input:
+        apiVersion: msgraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryType: UserValidation
+        # Replace with actual user principal names from your directory
+        users:
+          - "user@example.onmicrosoft.com"
+        target: "status.validatedUsers"
+        skipQueryWhenTargetHasData: true
+        # Extra Microsoft Graph user properties to include in the result.
+        # These are appended to the default fields: id, displayName,
+        # userPrincipalName, mail.
+        # Supported values: any standard Graph user property (camelCase)
+        # or OData extension attribute (e.g. extension_<appId>_<name>).
+        # If a field has no value set in Entra ID it is silently omitted
+        # from the result (Debug log emitted). If the field name is wrong
+        # an Info log is emitted and the field is omitted.
+        additionalFields:
+          - city
+          - country
+          - department
+          - jobTitle
+          - usageLocation
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: crossplane-system
+            name: azure-account-creds

--- a/fn.go
+++ b/fn.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -81,6 +82,209 @@ const (
 	servicePrincipalType = "servicePrincipal"
 	unknownType          = "unknown"
 )
+
+// graphFieldNameRE matches the shape of a Microsoft Graph property name,
+// including OData extension attributes (extension_<appId>_<name>).
+var graphFieldNameRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+
+// normalizeGraphValue converts a value resolved from a Graph SDK model into a
+// JSON-safe representation. Both result targets require this: status targets are
+// serialized with encoding/json, and kiota model structs keep their state in an
+// unexported backing store, so they would marshal to an empty object; context
+// targets go through structpb.NewValue, which rejects anything that is not a
+// JSON scalar, map[string]interface{} or []interface{}.
+// The second return value is false when the value cannot be represented.
+func normalizeGraphValue(v interface{}) (interface{}, bool) { //nolint:gocyclo // multiple type cases are inherent to value normalisation
+	switch t := v.(type) {
+	case nil:
+		return nil, false
+	case string, bool, int, int32, int64, float32, float64:
+		return t, true
+	case []byte:
+		return base64.StdEncoding.EncodeToString(t), true
+	case time.Time:
+		return t.Format(time.RFC3339), true
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, e := range t {
+			if nv, ok := normalizeGraphValue(e); ok {
+				out[k] = nv
+			}
+		}
+		return out, true
+	}
+
+	rv := reflect.ValueOf(v)
+	// Dereference first so that, for example, *time.Time reaches the case above.
+	if rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return nil, false
+		}
+		return normalizeGraphValue(rv.Elem().Interface())
+	}
+	// Graph enums and identifier types (uuid.UUID and friends) render as strings.
+	if s, ok := v.(fmt.Stringer); ok {
+		return s.String(), true
+	}
+	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+		out := make([]interface{}, 0, rv.Len())
+		for i := range rv.Len() {
+			if nv, ok := normalizeGraphValue(rv.Index(i).Interface()); ok {
+				out = append(out, nv)
+			}
+		}
+		return out, true
+	}
+
+	return nil, false
+}
+
+// callTypedGetter invokes a no-argument getter method on obj by reflection.
+// Returns (value, found, hasGetter):
+//   - hasGetter=false: no method with the expected name/signature exists.
+//   - hasGetter=true, found=false: method exists but returned nil/zero (field not set).
+//   - hasGetter=true, found=true: method returned a non-nil/non-zero value.
+func callTypedGetter(obj interface{}, methodName string) (interface{}, bool, bool) {
+	m := reflect.ValueOf(obj).MethodByName(methodName)
+	if !m.IsValid() || m.Type().NumIn() != 0 || m.Type().NumOut() != 1 {
+		return nil, false, false
+	}
+	rv := m.Call(nil)[0]
+	if rv.Kind() == reflect.Pointer && !rv.IsNil() {
+		return rv.Elem().Interface(), true, true
+	}
+	if rv.IsValid() && !rv.IsZero() {
+		return rv.Interface(), true, true
+	}
+	return nil, false, true
+}
+
+// lookupAdditionalData checks whether field is present in the object's OData
+// additional data bag (used for extension attributes not modelled as typed fields).
+func lookupAdditionalData(obj interface{}, field string) (interface{}, bool) {
+	type additionalDataProvider interface {
+		GetAdditionalData() map[string]interface{}
+	}
+	if adder, ok := obj.(additionalDataProvider); ok {
+		val, exists := adder.GetAdditionalData()[field]
+		return val, exists
+	}
+	return nil, false
+}
+
+// filterSelectFields returns the subset of additionalFields that are safe to
+// include in a Graph API $select expression. A field is accepted when it
+// either has a typed getter on modelPtr (checked by reflection) or matches
+// the OData extension-attribute naming convention (extension_*). Rejected
+// fields are logged at Info level and omitted so that Graph never returns a
+// 400 for an unrecognised property name.
+func (g *GraphQuery) filterSelectFields(additionalFields []string, modelPtr interface{}) []string {
+	if len(additionalFields) == 0 {
+		return nil
+	}
+	t := reflect.TypeOf(modelPtr)
+	out := make([]string, 0, len(additionalFields))
+	for _, field := range additionalFields {
+		if len(field) == 0 {
+			continue
+		}
+		methodName := "Get" + strings.ToUpper(field[:1]) + field[1:]
+		if _, ok := t.MethodByName(methodName); ok {
+			out = append(out, field)
+			continue
+		}
+		if strings.HasPrefix(field, "extension_") {
+			out = append(out, field)
+			continue
+		}
+		if g.log != nil {
+			g.log.Info("additionalFields: field not recognised — verify the field name; skipping to prevent Graph API 400",
+				"field", field, "model", t.String())
+		}
+	}
+	return out
+}
+
+// sanitizeAdditionalFields drops entries that are not valid Graph property
+// names. Names are interpolated into OData $select and $expand expressions, so
+// an unvalidated entry can inject extra query options or produce a malformed
+// expression that Graph rejects with 400.
+func (g *GraphQuery) sanitizeAdditionalFields(fields []string) []string {
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if !graphFieldNameRE.MatchString(f) {
+			if g.log != nil {
+				g.log.Info("additionalFields: ignoring invalid Graph property name", "field", f)
+			}
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// applyAdditionalFields extracts each requested field from obj and stores
+// found values in m. It is a convenience wrapper around extractTypedOrAdditionalField.
+func (g *GraphQuery) applyAdditionalFields(m map[string]interface{}, obj interface{}, objectID string, fields []string) {
+	for _, field := range fields {
+		val, ok := g.extractTypedOrAdditionalField(obj, field, objectID)
+		if !ok {
+			continue
+		}
+		normalized, ok := normalizeGraphValue(val)
+		if !ok {
+			// Structured Graph types have no faithful JSON-safe form here. Skipping
+			// with a log is preferable to writing an empty object to the target.
+			if g.log != nil {
+				g.log.Info("additionalFields: field has a complex type that cannot be stored at the target, skipping",
+					"field", field, "objectID", objectID, "type", fmt.Sprintf("%T", val))
+			}
+			continue
+		}
+		m[field] = normalized
+	}
+}
+
+// extractTypedOrAdditionalField resolves a field value from a Microsoft Graph
+// SDK model object. It first attempts to call the typed getter derived from
+// the field name (e.g. "city" → GetCity(), "jobTitle" → GetJobTitle()) using
+// reflection. This is necessary because the kiota-generated SDK deserializes
+// known properties into typed struct fields, not into GetAdditionalData().
+// If no typed getter exists (e.g. for OData extension attributes), the
+// method falls back to GetAdditionalData().
+//
+// Logging behaviour:
+//   - Debug: field is a known SDK property but has no value set for this object
+//     (e.g. user.city is empty in Entra ID) — expected, no action needed.
+//   - Info:  field is not found via typed getter OR additionalData — likely a
+//     typo or unsupported field name in additionalFields config.
+func (g *GraphQuery) extractTypedOrAdditionalField(obj interface{}, field, objectID string) (interface{}, bool) {
+	if len(field) == 0 {
+		return nil, false
+	}
+	// Build the expected getter name: "city" → "GetCity", "jobTitle" → "GetJobTitle"
+	methodName := "Get" + strings.ToUpper(field[:1]) + field[1:]
+	if val, found, hasGetter := callTypedGetter(obj, methodName); hasGetter {
+		if found {
+			return val, true
+		}
+		// Typed getter exists but returned nil/zero — field is known but not set.
+		if g.log != nil {
+			g.log.Debug("additionalFields: field is a valid Graph property but has no value for this object",
+				"field", field, "objectID", objectID)
+		}
+		return nil, false
+	}
+	if val, found := lookupAdditionalData(obj, field); found {
+		return val, true
+	}
+	// Field not found anywhere — likely a typo or unsupported field name.
+	if g.log != nil {
+		g.log.Info("additionalFields: field not found in Graph SDK model or additionalData — verify the field name in additionalFields config",
+			"field", field, "objectID", objectID)
+	}
+	return nil, false
+}
 
 // GraphQueryInterface defines the methods required for querying Microsoft Graph API.
 type GraphQueryInterface interface {
@@ -507,6 +711,8 @@ func (g *GraphQuery) graphQuery(ctx context.Context, azureCreds map[string]strin
 		return nil, err
 	}
 
+	in.AdditionalFields = g.sanitizeAdditionalFields(in.AdditionalFields)
+
 	// Route based on query type
 	switch in.QueryType {
 	case "UserValidation":
@@ -530,6 +736,7 @@ func (g *GraphQuery) validateUsers(ctx context.Context, client *msgraphsdk.Graph
 
 	results := make([]interface{}, 0)
 	requireActiveAccount := ptr.Deref(in.ActiveAccount, false)
+	validExtra := g.filterSelectFields(in.AdditionalFields, (*models.User)(nil))
 
 	for _, userPrincipalName := range in.Users {
 		if userPrincipalName == nil {
@@ -545,9 +752,12 @@ func (g *GraphQuery) validateUsers(ctx context.Context, client *msgraphsdk.Graph
 		filterValue := fmt.Sprintf("userPrincipalName eq '%s'", *userPrincipalName)
 		requestConfig.QueryParameters.Filter = &filterValue
 
-		// Use standard fields for user validation. accountEnabled is returned by
-		// Microsoft Graph only when it is explicitly selected.
-		requestConfig.QueryParameters.Select = []string{"id", fieldDisplayName, fieldUserPrincipalName, fieldMail, fieldAccountEnabled}
+		// Use standard fields for user validation, appending any extra fields requested.
+		// accountEnabled is returned by Microsoft Graph only when explicitly selected.
+		selectFields := make([]string, 0, 5+len(validExtra))
+		selectFields = append(selectFields, "id", fieldDisplayName, fieldUserPrincipalName, fieldMail, fieldAccountEnabled)
+		selectFields = append(selectFields, validExtra...)
+		requestConfig.QueryParameters.Select = selectFields
 
 		// Execute the query
 		result, err := client.Users().Get(ctx, requestConfig)
@@ -556,7 +766,7 @@ func (g *GraphQuery) validateUsers(ctx context.Context, client *msgraphsdk.Graph
 		}
 
 		// Process results
-		results = append(results, g.buildUserResults(result.GetValue(), requireActiveAccount)...)
+		results = append(results, g.buildUserResults(result.GetValue(), requireActiveAccount, validExtra)...)
 	}
 
 	return results, nil
@@ -567,7 +777,7 @@ func (g *GraphQuery) validateUsers(ctx context.Context, client *msgraphsdk.Graph
 // attribute is not true are omitted. A nil attribute is treated as disabled,
 // because Microsoft Graph returns accountEnabled only when it is explicitly
 // selected, so an absent value means the account state is unconfirmed.
-func (g *GraphQuery) buildUserResults(graphUsers []models.Userable, requireActiveAccount bool) []interface{} {
+func (g *GraphQuery) buildUserResults(graphUsers []models.Userable, requireActiveAccount bool, additionalFields []string) []interface{} {
 	results := make([]interface{}, 0, len(graphUsers))
 
 	for _, user := range graphUsers {
@@ -582,13 +792,15 @@ func (g *GraphQuery) buildUserResults(graphUsers []models.Userable, requireActiv
 			continue
 		}
 
-		results = append(results, map[string]interface{}{
+		userMap := map[string]interface{}{
 			"id":                   ptr.Deref(user.GetId(), ""),
 			fieldDisplayName:       ptr.Deref(user.GetDisplayName(), ""),
 			fieldUserPrincipalName: ptr.Deref(user.GetUserPrincipalName(), ""),
 			fieldMail:              ptr.Deref(user.GetMail(), ""),
 			fieldAccountEnabled:    accountEnabled,
-		})
+		}
+		g.applyAdditionalFields(userMap, user, ptr.Deref(user.GetId(), "unknown"), additionalFields)
+		results = append(results, userMap)
 	}
 
 	return results
@@ -619,18 +831,23 @@ func (g *GraphQuery) findGroupByName(ctx context.Context, client *msgraphsdk.Gra
 	return groupResult.GetValue()[0].GetId(), nil
 }
 
-// fetchGroupMembers fetches all members of a group by group ID
-func (g *GraphQuery) fetchGroupMembers(ctx context.Context, client *msgraphsdk.GraphServiceClient, groupID string, groupName string) ([]models.DirectoryObjectable, error) {
-	// Create a request configuration that expands members
-	// This is the workaround for the known issue where service principals
-	// are not listed as group members in v1.0
+// fetchGroupMembers fetches all members of a group by group ID.
+// additionalFields extends the nested $select inside the $expand expression.
+func (g *GraphQuery) fetchGroupMembers(ctx context.Context, client *msgraphsdk.GraphServiceClient, groupID string, groupName string, additionalFields []string) ([]models.DirectoryObjectable, error) {
+	// Build the nested $select list for the $expand workaround.
+	// The workaround is required because service principals are not listed as
+	// group members via the standard /members endpoint in v1.0.
 	// See: https://developer.microsoft.com/en-us/graph/known-issues/?search=25984
+	memberSelectFields := append(
+		[]string{"id", "displayName", "mail", "userPrincipalName", "appId"},
+		additionalFields...,
+	)
 	requestConfig := &groups.GroupItemRequestBuilderGetRequestConfiguration{
 		QueryParameters: &groups.GroupItemRequestBuilderGetQueryParameters{
-			// Explicitly select the standard member fields via a nested $select so
-			// that user properties such as mail and userPrincipalName are returned
-			// for the expanded members (see issue #115).
-			Expand: []string{"members($select=id,displayName,mail,userPrincipalName,appId)"},
+			// Explicitly select member fields via a nested $select so that user
+			// properties such as mail and userPrincipalName are returned for the
+			// expanded members (see issue #115).
+			Expand: []string{fmt.Sprintf("members($select=%s)", strings.Join(memberSelectFields, ","))},
 		},
 	}
 
@@ -806,16 +1023,22 @@ func (g *GraphQuery) getGroupMembers(ctx context.Context, client *msgraphsdk.Gra
 		return nil, err
 	}
 
-	// Fetch the members
-	memberObjects, err := g.fetchGroupMembers(ctx, client, *groupID, groupName)
+	// Filter additionalFields up front so the nested $select never gets an
+	// unrecognised property name (which would cause Graph to return 400).
+	// Members are predominantly users, so we validate against models.User.
+	validExtra := g.filterSelectFields(in.AdditionalFields, (*models.User)(nil))
+
+	// Fetch the members, forwarding any extra fields for the nested $select
+	memberObjects, err := g.fetchGroupMembers(ctx, client, *groupID, groupName, validExtra)
 	if err != nil {
 		return nil, err
 	}
 
-	// Process the members
+	// Process the members and attach any additional fields from additionalData
 	members := make([]interface{}, 0, len(memberObjects))
 	for _, member := range memberObjects {
 		memberMap := g.processMember(member)
+		g.applyAdditionalFields(memberMap, member, ptr.Deref(member.GetId(), "unknown"), validExtra)
 		members = append(members, memberMap)
 	}
 
@@ -829,6 +1052,7 @@ func (g *GraphQuery) getGroupObjectIDs(ctx context.Context, client *msgraphsdk.G
 	}
 
 	results := make([]interface{}, 0)
+	validExtra := g.filterSelectFields(in.AdditionalFields, (*models.Group)(nil))
 
 	for _, groupName := range in.Groups {
 		if groupName == nil {
@@ -844,8 +1068,11 @@ func (g *GraphQuery) getGroupObjectIDs(ctx context.Context, client *msgraphsdk.G
 		filterValue := fmt.Sprintf("displayName eq '%s'", *groupName)
 		requestConfig.QueryParameters.Filter = &filterValue
 
-		// Use standard fields for group object IDs
-		requestConfig.QueryParameters.Select = []string{"id", fieldDisplayName, fieldDescription}
+		// Use standard fields for group object IDs, appending any extra fields requested
+		selectFields := make([]string, 0, 3+len(validExtra))
+		selectFields = append(selectFields, "id", fieldDisplayName, fieldDescription)
+		selectFields = append(selectFields, validExtra...)
+		requestConfig.QueryParameters.Select = selectFields
 
 		groupResult, err := client.Groups().Get(ctx, requestConfig)
 		if err != nil {
@@ -859,6 +1086,7 @@ func (g *GraphQuery) getGroupObjectIDs(ctx context.Context, client *msgraphsdk.G
 					fieldDisplayName: ptr.Deref(group.GetDisplayName(), ""),
 					fieldDescription: ptr.Deref(group.GetDescription(), ""),
 				}
+				g.applyAdditionalFields(groupMap, group, ptr.Deref(group.GetId(), "unknown"), validExtra)
 				results = append(results, groupMap)
 			}
 		}
@@ -874,6 +1102,7 @@ func (g *GraphQuery) getServicePrincipalDetails(ctx context.Context, client *msg
 	}
 
 	results := make([]interface{}, 0)
+	validExtra := g.filterSelectFields(in.AdditionalFields, (*models.ServicePrincipal)(nil))
 
 	for _, spName := range in.ServicePrincipals {
 		if spName == nil {
@@ -889,8 +1118,11 @@ func (g *GraphQuery) getServicePrincipalDetails(ctx context.Context, client *msg
 		filterValue := fmt.Sprintf("displayName eq '%s'", *spName)
 		requestConfig.QueryParameters.Filter = &filterValue
 
-		// Use standard fields for service principals
-		requestConfig.QueryParameters.Select = []string{"id", fieldAppID, fieldDisplayName, fieldDescription}
+		// Use standard fields for service principals, appending any extra fields requested
+		selectFields := make([]string, 0, 4+len(validExtra))
+		selectFields = append(selectFields, "id", fieldAppID, fieldDisplayName, fieldDescription)
+		selectFields = append(selectFields, validExtra...)
+		requestConfig.QueryParameters.Select = selectFields
 
 		spResult, err := client.ServicePrincipals().Get(ctx, requestConfig)
 		if err != nil {
@@ -905,6 +1137,7 @@ func (g *GraphQuery) getServicePrincipalDetails(ctx context.Context, client *msg
 					fieldDisplayName: ptr.Deref(sp.GetDisplayName(), ""),
 					fieldDescription: ptr.Deref(sp.GetDescription(), ""),
 				}
+				g.applyAdditionalFields(spMap, sp, ptr.Deref(sp.GetId(), "unknown"), validExtra)
 				results = append(results, spMap)
 			}
 		}

--- a/fn_test.go
+++ b/fn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -22,15 +23,19 @@ import (
 
 const (
 	// Repeated fixture values used across the table-driven tests.
-	testRequestTag     = "hello"
-	testCredentialsKey = "credentials"
-	testAzureCredsName = "azure-creds"
-	testSPID1          = "sp-id-1"
-	testUserID1        = "user-id-1"
-	testUserDisplay    = "Test User"
-	testUser1Email     = "user1@example.com"
-	testUser2Email     = "user2@example.com"
-	watchedResourceKey = "ops.crossplane.io/watched-resource"
+	testRequestTag      = "hello"
+	testCredentialsKey  = "credentials"
+	testAzureCredsName  = "azure-creds"
+	testSPID1           = "sp-id-1"
+	testUserID1         = "user-id-1"
+	testUserIDDefault   = "test-user-id"
+	testUserDisplay     = "Test User"
+	testUser1Email      = "user1@example.com"
+	testUser2Email      = "user2@example.com"
+	testExampleEmail    = "user@example.com"
+	testFieldCity       = "city"
+	testFieldDepartment = "department"
+	watchedResourceKey  = "ops.crossplane.io/watched-resource"
 
 	// Condition fields asserted on successful function responses.
 	condTypeFunctionSuccess = "FunctionSuccess"
@@ -1597,7 +1602,7 @@ func TestResolveUsersRef(t *testing.T) {
 								userID = "admin-id"
 								displayName = "Admin User"
 							default:
-								userID = "test-user-id"
+								userID = testUserIDDefault
 								displayName = testUserDisplay
 							}
 
@@ -3990,7 +3995,7 @@ func TestRunFunction(t *testing.T) {
 							// and the remaining one carries accountEnabled.
 							return []interface{}{
 								map[string]interface{}{
-									"id":                   "test-user-id",
+									"id":                   testUserIDDefault,
 									fieldDisplayName:       testUserDisplay,
 									fieldUserPrincipalName: "user@example.com",
 									fieldMail:              "user@example.com",
@@ -4000,7 +4005,7 @@ func TestRunFunction(t *testing.T) {
 						}
 						return []interface{}{
 							map[string]interface{}{
-								"id":                   "test-user-id",
+								"id":                   testUserIDDefault,
 								fieldDisplayName:       testUserDisplay,
 								fieldUserPrincipalName: "user@example.com",
 								fieldMail:              "user@example.com",
@@ -4294,6 +4299,253 @@ func TestIdentityType(t *testing.T) {
 	}
 }
 
+// TestAdditionalFields verifies that AdditionalFields is propagated to the graph
+// query and that extra fields appear in the RunFunction response for every
+// supported queryType (UserValidation, GroupObjectIDs, ServicePrincipalDetails,
+// GroupMembership).
+func TestAdditionalFields(t *testing.T) {
+	xr := `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2}}`
+	creds := &fnv1.CredentialData{
+		Data: map[string][]byte{
+			testCredentialsKey: []byte(`{
+"clientId": "test-client-id",
+"clientSecret": "test-client-secret",
+"subscriptionId": "test-subscription-id",
+"tenantId": "test-tenant-id"
+}`),
+		},
+	}
+
+	cases := map[string]struct {
+		reason            string
+		inputJSON         string
+		wantExtraFields   []string
+		wantStatusPayload string
+		// mockResult is the value the mock graphQuery returns for this case
+		mockResult func(in *v1beta1.Input) (interface{}, error)
+	}{
+		// ── UserValidation ────────────────────────────────────────────────────────
+		"UserValidationWithAdditionalFields": {
+			reason: "additionalFields must be forwarded and appear in UserValidation results",
+			inputJSON: `{
+				"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+				"kind": "Input",
+				"queryType": "UserValidation",
+				"users": ["user@example.com"],
+				"target": "status.validatedUsers",
+				"additionalFields": ["city", "department"]
+			}`,
+			wantExtraFields: []string{testFieldCity, testFieldDepartment},
+			wantStatusPayload: `{"validatedUsers":[{
+				"id":"test-user-id","displayName":"Test User",
+				"userPrincipalName":"user@example.com","mail":"user@example.com",
+				"city":"Kyiv","department":"Tech Ops"
+			}]}`,
+			mockResult: func(in *v1beta1.Input) (interface{}, error) {
+				m := map[string]interface{}{
+					"id": testUserIDDefault, fieldDisplayName: testUserDisplay,
+					fieldUserPrincipalName: testExampleEmail, fieldMail: testExampleEmail,
+				}
+				for _, f := range in.AdditionalFields {
+					switch f {
+					case testFieldCity:
+						m[testFieldCity] = "Kyiv"
+					case testFieldDepartment:
+						m[testFieldDepartment] = "Tech Ops"
+					}
+				}
+				return []interface{}{m}, nil
+			},
+		},
+		"UserValidationBackwardCompat": {
+			reason: "omitting additionalFields must yield only the default four fields",
+			inputJSON: `{
+				"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+				"kind": "Input",
+				"queryType": "UserValidation",
+				"users": ["user@example.com"],
+				"target": "status.validatedUsers"
+			}`,
+			wantExtraFields: nil,
+			wantStatusPayload: `{"validatedUsers":[{
+				"id":"test-user-id","displayName":"Test User",
+				"userPrincipalName":"user@example.com","mail":"user@example.com"
+			}]}`,
+			mockResult: func(_ *v1beta1.Input) (interface{}, error) {
+				return []interface{}{map[string]interface{}{
+					"id": testUserIDDefault, fieldDisplayName: testUserDisplay,
+					fieldUserPrincipalName: testExampleEmail, fieldMail: testExampleEmail,
+				}}, nil
+			},
+		},
+		// ── GroupObjectIDs ───────────────────────────────────────────────────────
+		"GroupObjectIDsWithAdditionalFields": {
+			reason: "additionalFields must be forwarded and appear in GroupObjectIDs results",
+			inputJSON: `{
+				"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+				"kind": "Input",
+				"queryType": "GroupObjectIDs",
+				"groups": ["Developers"],
+				"target": "status.groupObjectIDs",
+				"additionalFields": ["mailNickname", "visibility"]
+			}`,
+			wantExtraFields: []string{"mailNickname", "visibility"},
+			wantStatusPayload: `{"groupObjectIDs":[{
+				"id":"group-id-1","displayName":"Developers","description":"Dev team",
+				"mailNickname":"devs","visibility":"Private"
+			}]}`,
+			mockResult: func(in *v1beta1.Input) (interface{}, error) {
+				m := map[string]interface{}{
+					"id": "group-id-1", fieldDisplayName: "Developers", fieldDescription: "Dev team",
+				}
+				for _, f := range in.AdditionalFields {
+					switch f {
+					case "mailNickname":
+						m["mailNickname"] = "devs"
+					case "visibility":
+						m["visibility"] = "Private"
+					}
+				}
+				return []interface{}{m}, nil
+			},
+		},
+		// ── ServicePrincipalDetails ──────────────────────────────────────────────
+		"ServicePrincipalDetailsWithAdditionalFields": {
+			reason: "additionalFields must be forwarded and appear in ServicePrincipalDetails results",
+			inputJSON: `{
+				"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+				"kind": "Input",
+				"queryType": "ServicePrincipalDetails",
+				"servicePrincipals": ["MyApp"],
+				"target": "status.spDetails",
+				"additionalFields": ["servicePrincipalType", "homepage"]
+			}`,
+			wantExtraFields: []string{"servicePrincipalType", "homepage"},
+			wantStatusPayload: `{"spDetails":[{
+				"id":"sp-id-1","appId":"app-id-1","displayName":"MyApp","description":"",
+				"servicePrincipalType":"Application","homepage":"https://myapp.example.com"
+			}]}`,
+			mockResult: func(in *v1beta1.Input) (interface{}, error) {
+				m := map[string]interface{}{
+					"id": "sp-id-1", fieldAppID: "app-id-1",
+					fieldDisplayName: "MyApp", fieldDescription: "",
+				}
+				for _, f := range in.AdditionalFields {
+					switch f {
+					case "servicePrincipalType":
+						m["servicePrincipalType"] = "Application"
+					case "homepage":
+						m["homepage"] = "https://myapp.example.com"
+					}
+				}
+				return []interface{}{m}, nil
+			},
+		},
+		// ── GroupMembership ──────────────────────────────────────────────────────
+		"GroupMembershipWithAdditionalFields": {
+			reason: "additionalFields must be forwarded and appear in GroupMembership member results",
+			inputJSON: `{
+				"apiVersion": "msgraph.fn.crossplane.io/v1alpha1",
+				"kind": "Input",
+				"queryType": "GroupMembership",
+				"group": "Developers",
+				"target": "status.members",
+				"additionalFields": ["department", "jobTitle"]
+			}`,
+			wantExtraFields: []string{testFieldDepartment, "jobTitle"},
+			wantStatusPayload: `{"members":[{
+				"id":"user-id-1","displayName":"Test User","type":"user",
+				"mail":"user1@example.com","userPrincipalName":"user1@example.com",
+				"department":"Engineering","jobTitle":"Staff Engineer"
+			}]}`,
+			mockResult: func(in *v1beta1.Input) (interface{}, error) {
+				m := map[string]interface{}{
+					"id": testUserID1, fieldDisplayName: testUserDisplay, fieldType: userType,
+					fieldMail: testUser1Email, fieldUserPrincipalName: testUser1Email,
+				}
+				for _, f := range in.AdditionalFields {
+					switch f {
+					case testFieldDepartment:
+						m[testFieldDepartment] = "Engineering"
+					case "jobTitle":
+						m["jobTitle"] = "Staff Engineer"
+					}
+				}
+				return []interface{}{m}, nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var capturedAdditionalFields []string
+
+			mockQuery := &MockGraphQuery{
+				GraphQueryFunc: func(_ context.Context, _ map[string]string, in *v1beta1.Input) (interface{}, error) {
+					capturedAdditionalFields = in.AdditionalFields
+					return tc.mockResult(in)
+				},
+			}
+
+			f := &Function{
+				graphQuery: mockQuery,
+				timer:      &MockTimer{},
+				log:        logging.NewNopLogger(),
+			}
+
+			req := &fnv1.RunFunctionRequest{
+				Meta:  &fnv1.RequestMeta{Tag: testRequestTag},
+				Input: resource.MustStructJSON(tc.inputJSON),
+				Observed: &fnv1.State{
+					Composite: &fnv1.Resource{
+						Resource: resource.MustStructJSON(xr),
+					},
+				},
+				Credentials: map[string]*fnv1.Credentials{
+					testAzureCredsName: {
+						Source: &fnv1.Credentials_CredentialData{CredentialData: creds},
+					},
+				},
+			}
+
+			rsp, err := f.RunFunction(context.Background(), req)
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.reason, err)
+			}
+
+			// AdditionalFields must be forwarded to the mock as-is.
+			if diff := cmp.Diff(tc.wantExtraFields, capturedAdditionalFields, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("%s\nAdditionalFields forwarded to query: -want +got:\n%s", tc.reason, diff)
+			}
+
+			// FunctionSuccess condition must be true.
+			var successCond *fnv1.Condition
+			for _, c := range rsp.GetConditions() {
+				if c.GetType() == condTypeFunctionSuccess {
+					successCond = c
+					break
+				}
+			}
+			if successCond == nil || successCond.GetStatus() != fnv1.Status_STATUS_CONDITION_TRUE {
+				t.Errorf("%s: expected FunctionSuccess=True condition, got: %v", tc.reason, rsp.GetConditions())
+			}
+
+			// Desired XR status must match expected payload.
+			wantDesired := resource.MustStructJSON(`{
+				"apiVersion": "example.org/v1",
+				"kind": "XR",
+				"metadata": {"name": "cool-xr"},
+				"spec": {"count": 2},
+				"status": ` + tc.wantStatusPayload + `
+			}`)
+			gotDesired := rsp.GetDesired().GetComposite().GetResource()
+			if diff := cmp.Diff(wantDesired, gotDesired, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\ndesired XR: -want +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 // newTestUser builds a typed user directory object, mirroring how the Graph SDK
 // deserializes expanded group members (the values land on the typed struct, not
 // in additionalData).
@@ -4382,6 +4634,7 @@ func TestBuildUserResults(t *testing.T) {
 		reason               string
 		graphUsers           []models.Userable
 		requireActiveAccount bool
+		additionalFields     []string
 		want                 []interface{}
 	}{
 		"FlagOffKeepsDisabledUsers": {
@@ -4479,17 +4732,261 @@ func TestBuildUserResults(t *testing.T) {
 				},
 			},
 		},
+		"AdditionalFieldsTypedScalar": {
+			reason: "A typed scalar additional field (city) is extracted and returned as a string",
+			graphUsers: func() []models.Userable {
+				u := models.NewUser()
+				u.SetId(ptr.To(testUserID1))
+				u.SetUserPrincipalName(ptr.To(testUser1Email))
+				u.SetMail(ptr.To(testUser1Email))
+				u.SetDisplayName(ptr.To(testUserDisplay))
+				u.SetAccountEnabled(ptr.To(true))
+				u.SetCity(ptr.To("Kyiv"))
+				return []models.Userable{u}
+			}(),
+			requireActiveAccount: false,
+			additionalFields:     []string{testFieldCity},
+			want: []interface{}{
+				map[string]interface{}{
+					"id":                   testUserID1,
+					fieldDisplayName:       testUserDisplay,
+					fieldUserPrincipalName: testUser1Email,
+					fieldMail:              testUser1Email,
+					fieldAccountEnabled:    true,
+					testFieldCity:          "Kyiv",
+				},
+			},
+		},
+		"AdditionalFieldsNonScalarSlice": {
+			reason: "A []string field (businessPhones) is normalised to []interface{} so it can be serialised",
+			graphUsers: func() []models.Userable {
+				u := models.NewUser()
+				u.SetId(ptr.To(testUserID1))
+				u.SetUserPrincipalName(ptr.To(testUser1Email))
+				u.SetMail(ptr.To(testUser1Email))
+				u.SetDisplayName(ptr.To(testUserDisplay))
+				u.SetAccountEnabled(ptr.To(true))
+				u.SetBusinessPhones([]string{"+1-555-0100"})
+				return []models.Userable{u}
+			}(),
+			requireActiveAccount: false,
+			additionalFields:     []string{"businessPhones"},
+			want: []interface{}{
+				map[string]interface{}{
+					"id":                   testUserID1,
+					fieldDisplayName:       testUserDisplay,
+					fieldUserPrincipalName: testUser1Email,
+					fieldMail:              testUser1Email,
+					fieldAccountEnabled:    true,
+					"businessPhones":       []interface{}{"+1-555-0100"},
+				},
+			},
+		},
+		"AdditionalFieldsNonScalarTime": {
+			reason: "A *time.Time field (createdDateTime) is normalised to RFC3339 string so it can be serialised",
+			graphUsers: func() []models.Userable {
+				u := models.NewUser()
+				u.SetId(ptr.To(testUserID1))
+				u.SetUserPrincipalName(ptr.To(testUser1Email))
+				u.SetMail(ptr.To(testUser1Email))
+				u.SetDisplayName(ptr.To(testUserDisplay))
+				u.SetAccountEnabled(ptr.To(true))
+				u.SetCreatedDateTime(ptr.To(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)))
+				return []models.Userable{u}
+			}(),
+			requireActiveAccount: false,
+			additionalFields:     []string{"createdDateTime"},
+			want: []interface{}{
+				map[string]interface{}{
+					"id":                   testUserID1,
+					fieldDisplayName:       testUserDisplay,
+					fieldUserPrincipalName: testUser1Email,
+					fieldMail:              testUser1Email,
+					fieldAccountEnabled:    true,
+					"createdDateTime":      "2024-01-02T03:04:05Z",
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			g := &GraphQuery{log: logging.NewNopLogger()}
-			got := g.buildUserResults(tc.graphUsers, tc.requireActiveAccount)
+			got := g.buildUserResults(tc.graphUsers, tc.requireActiveAccount, tc.additionalFields)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("%s\nbuildUserResults(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}
+}
+
+// TestApplyAdditionalFieldsSerialisation verifies that non-scalar Graph values
+// ([]string, *time.Time) survive the full serialisation path through
+// putQueryResultToContext without error. This is the regression test for the
+// proto: invalid type bug.
+func TestApplyAdditionalFieldsSerialisation(t *testing.T) {
+	u := models.NewUser()
+	u.SetId(ptr.To("uid-1"))
+	u.SetDisplayName(ptr.To("Test User"))
+	u.SetUserPrincipalName(ptr.To("test@example.com"))
+	u.SetMail(ptr.To("test@example.com"))
+	u.SetAccountEnabled(ptr.To(true))
+	u.SetBusinessPhones([]string{"+1-555-0100"})
+	u.SetCreatedDateTime(ptr.To(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)))
+
+	g := &GraphQuery{log: logging.NewNopLogger()}
+	results := g.buildUserResults([]models.Userable{u}, false, []string{"businessPhones", "createdDateTime"})
+
+	req := &fnv1.RunFunctionRequest{}
+	rsp := &fnv1.RunFunctionResponse{}
+	f := &Function{log: logging.NewNopLogger()}
+	in := &v1beta1.Input{Target: "context.validatedUsers"}
+
+	if err := putQueryResultToContext(req, rsp, in, results, f); err != nil {
+		t.Fatalf("putQueryResultToContext returned unexpected error: %v", err)
+	}
+
+	got := rsp.GetContext().GetFields()["validatedUsers"].AsInterface()
+	entries, ok := got.([]interface{})
+	if !ok || len(entries) != 1 {
+		t.Fatalf("expected 1 entry in context, got %v", got)
+	}
+	entry, ok := entries[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map entry, got %T", entries[0])
+	}
+	if diff := cmp.Diff([]interface{}{"+1-555-0100"}, entry["businessPhones"]); diff != "" {
+		t.Errorf("businessPhones: -want, +got:\n%s", diff)
+	}
+	if diff := cmp.Diff("2024-01-02T03:04:05Z", entry["createdDateTime"]); diff != "" {
+		t.Errorf("createdDateTime: -want, +got:\n%s", diff)
+	}
+}
+
+// TestSanitizeAdditionalFields verifies that sanitizeAdditionalFields drops
+// entries that are not valid Graph property names and passes through valid ones.
+func TestSanitizeAdditionalFields(t *testing.T) {
+	g := &GraphQuery{log: logging.NewNopLogger()}
+
+	cases := map[string]struct {
+		input []string
+		want  []string
+	}{
+		"ValidFieldsPassThrough": {
+			input: []string{testFieldCity, testFieldDepartment, "extension_abc_costCenter"},
+			want:  []string{testFieldCity, testFieldDepartment, "extension_abc_costCenter"},
+		},
+		"EmptyStringDropped": {
+			input: []string{testFieldCity, "", testFieldDepartment},
+			want:  []string{testFieldCity, testFieldDepartment},
+		},
+		"ODataInjectionDropped": {
+			input: []string{"id),manager($select=id,displayName"},
+			want:  []string{},
+		},
+		"SpaceInNameDropped": {
+			input: []string{"display Name"},
+			want:  []string{},
+		},
+		"NilInputReturnsEmpty": {
+			input: nil,
+			want:  []string{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := g.sanitizeAdditionalFields(tc.input)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("sanitizeAdditionalFields: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestApplyAdditionalFieldsByModel verifies that applyAdditionalFields correctly
+// extracts typed getter values from each Graph model type used across the four
+// query types. This ensures reflection-based extraction works for Group and
+// ServicePrincipal in addition to User (covered by TestBuildUserResults).
+func TestApplyAdditionalFieldsByModel(t *testing.T) {
+	g := &GraphQuery{log: logging.NewNopLogger()}
+
+	t.Run("GroupMailNickname", func(t *testing.T) {
+		grp := models.NewGroup()
+		grp.SetId(ptr.To("group-id-1"))
+		grp.SetMailNickname(ptr.To("eng-team"))
+
+		m := map[string]interface{}{}
+		g.applyAdditionalFields(m, grp, "group-id-1", []string{"mailNickname"})
+
+		if diff := cmp.Diff(map[string]interface{}{"mailNickname": "eng-team"}, m); diff != "" {
+			t.Errorf("Group mailNickname: -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("GroupSecurityEnabled", func(t *testing.T) {
+		grp := models.NewGroup()
+		grp.SetId(ptr.To("group-id-2"))
+		grp.SetSecurityEnabled(ptr.To(true))
+
+		m := map[string]interface{}{}
+		g.applyAdditionalFields(m, grp, "group-id-2", []string{"securityEnabled"})
+
+		if diff := cmp.Diff(map[string]interface{}{"securityEnabled": true}, m); diff != "" {
+			t.Errorf("Group securityEnabled: -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("ServicePrincipalType", func(t *testing.T) {
+		sp := models.NewServicePrincipal()
+		sp.SetId(ptr.To("sp-id-1"))
+		sp.SetServicePrincipalType(ptr.To("Application"))
+
+		m := map[string]interface{}{}
+		g.applyAdditionalFields(m, sp, "sp-id-1", []string{"servicePrincipalType"})
+
+		if diff := cmp.Diff(map[string]interface{}{"servicePrincipalType": "Application"}, m); diff != "" {
+			t.Errorf("ServicePrincipal servicePrincipalType: -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("ServicePrincipalHomepage", func(t *testing.T) {
+		sp := models.NewServicePrincipal()
+		sp.SetId(ptr.To("sp-id-2"))
+		sp.SetHomepage(ptr.To("https://example.com"))
+
+		m := map[string]interface{}{}
+		g.applyAdditionalFields(m, sp, "sp-id-2", []string{"homepage"})
+
+		if diff := cmp.Diff(map[string]interface{}{"homepage": "https://example.com"}, m); diff != "" {
+			t.Errorf("ServicePrincipal homepage: -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("GroupMemberUserDepartment", func(t *testing.T) {
+		u := models.NewUser()
+		u.SetId(ptr.To(testUserID1))
+		u.SetDepartment(ptr.To("Engineering"))
+
+		m := map[string]interface{}{}
+		g.applyAdditionalFields(m, u, testUserID1, []string{testFieldDepartment})
+
+		if diff := cmp.Diff(map[string]interface{}{testFieldDepartment: "Engineering"}, m); diff != "" {
+			t.Errorf("GroupMembership user department: -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("UnknownFieldSkipped", func(t *testing.T) {
+		grp := models.NewGroup()
+		grp.SetId(ptr.To("group-id-3"))
+
+		m := map[string]interface{}{}
+		g.applyAdditionalFields(m, grp, "group-id-3", []string{"nonExistentField"})
+
+		if len(m) != 0 {
+			t.Errorf("expected empty map for unknown field, got %v", m)
+		}
+	})
 }
 
 // TestProcessMember exercises the real member-extraction path (bypassed by the
@@ -4551,6 +5048,71 @@ func TestProcessMember(t *testing.T) {
 			got := g.processMember(tc.member)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("%s\nprocessMember(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// TestNormalizeGraphValue verifies that normalizeGraphValue converts non-scalar
+// Graph SDK values to JSON-safe types accepted by both structpb and encoding/json.
+func TestNormalizeGraphValue(t *testing.T) {
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	strVal := "CC-42"
+	f64Val := float64(7)
+
+	cases := map[string]struct {
+		input  interface{}
+		want   interface{}
+		wantOK bool
+	}{
+		"NilReturnsFalse": {
+			input: nil, want: nil, wantOK: false,
+		},
+		"StringPassthrough": {
+			input: "hello", want: "hello", wantOK: true,
+		},
+		"BoolPassthrough": {
+			input: true, want: true, wantOK: true,
+		},
+		"Float64Passthrough": {
+			input: float64(3.14), want: float64(3.14), wantOK: true,
+		},
+		"TimeFormattedAsRFC3339": {
+			input: ts, want: "2024-01-02T03:04:05Z", wantOK: true,
+		},
+		"PtrTimeDeref": {
+			input: &ts, want: "2024-01-02T03:04:05Z", wantOK: true,
+		},
+		"PtrStringDeref": {
+			input: &strVal, want: "CC-42", wantOK: true,
+		},
+		"PtrFloat64Deref": {
+			input: &f64Val, want: float64(7), wantOK: true,
+		},
+		"NilPtrReturnsFalse": {
+			input: (*string)(nil), want: nil, wantOK: false,
+		},
+		"ByteSliceBase64Encoded": {
+			input: []byte("hello"), want: "aGVsbG8=", wantOK: true,
+		},
+		"StringSliceToInterfaceSlice": {
+			input: []string{"a", "b"}, want: []interface{}{"a", "b"}, wantOK: true,
+		},
+		"MapStringInterface": {
+			input:  map[string]interface{}{"k": "v"},
+			want:   map[string]interface{}{"k": "v"},
+			wantOK: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, ok := normalizeGraphValue(tc.input)
+			if ok != tc.wantOK {
+				t.Errorf("normalizeGraphValue(%T): wantOK=%v got=%v", tc.input, tc.wantOK, ok)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("normalizeGraphValue(%T): -want, +got:\n%s", tc.input, diff)
 			}
 		})
 	}

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -95,6 +95,16 @@ type Input struct {
 	// +optional
 	ActiveAccount *bool `json:"activeAccount,omitempty"`
 
+	// AdditionalFields is a list of extra Microsoft Graph fields to include in query results.
+	// Supported for: UserValidation, GroupObjectIDs, ServicePrincipalDetails, GroupMembership.
+	// Fields are appended to the default set for each query type, e.g.:
+	//   UserValidation default:          id, displayName, userPrincipalName, mail
+	//   GroupObjectIDs default:          id, displayName, description
+	//   ServicePrincipalDetails default: id, appId, displayName, description
+	//   GroupMembership default:         id, displayName, type, mail, userPrincipalName, appId
+	// +optional
+	AdditionalFields []string `json:"additionalFields,omitempty"`
+
 	// Identity defines the type of identity used for authentication to the Microsoft Graph API.
 	Identity *Identity `json:"identity,omitempty"`
 }

--- a/input/v1beta1/zz_generated.deepcopy.go
+++ b/input/v1beta1/zz_generated.deepcopy.go
@@ -106,6 +106,11 @@ func (in *Input) DeepCopyInto(out *Input) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AdditionalFields != nil {
+		in, out := &in.AdditionalFields, &out.AdditionalFields
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Identity != nil {
 		in, out := &in.Identity, &out.Identity
 		*out = new(Identity)

--- a/package/input/msgraph.fn.crossplane.io_inputs.yaml
+++ b/package/input/msgraph.fn.crossplane.io_inputs.yaml
@@ -30,6 +30,18 @@ spec:
               If false or unset, users are validated on existence alone.
               Only applies to the UserValidation query type.
             type: boolean
+          additionalFields:
+            description: |-
+              AdditionalFields is a list of extra Microsoft Graph fields to include in query results.
+              Supported for: UserValidation, GroupObjectIDs, ServicePrincipalDetails, GroupMembership.
+              Fields are appended to the default set for each query type, e.g.:
+                UserValidation default:          id, displayName, userPrincipalName, mail
+                GroupObjectIDs default:          id, displayName, description
+                ServicePrincipalDetails default: id, appId, displayName, description
+                GroupMembership default:         id, displayName, type, mail, userPrincipalName, appId
+            items:
+              type: string
+            type: array
           apiVersion:
             description: |-
               APIVersion defines the versioned schema of this representation of an object.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Adds optional additionalFields []string to the Input type, allowing consumers to include extra Microsoft Graph API attributes in query results beyond the fixed default set. Supported for all four query types: UserValidation, GroupObjectIDs, ServicePrincipalDetails, and GroupMembership.

Implementation notes for reviewers:

Field values are resolved via reflection (GetCity(), GetJobTitle(), etc.) rather than GetAdditionalData(), because the kiota-generated SDK deserializes known Graph properties into typed struct fields — GetAdditionalData() only contains OData extension attributes. The helper falls back to additionalData for true extension attributes.
GroupMembership dynamically builds the nested $expand string (members($select=id,displayName,...,extraField)) to include additional fields in the Graph API request.
Unknown field names are logged at Info level and skipped — no reconcile failure.
Implement #121 
Tested with the crossplane v2.3.4

Fixes # 
README.md
example/user-validation-additional-fields-example.yaml
fn.go
fn_test.go
input/v1beta1/input.go
input/v1beta1/zz_generated.deepcopy.go
package/input/msgraph.fn.crossplane.io_inputs.yaml

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
