### PR TITLE
fix: bump example function-msgraph pins to v0.8.0

### DIFF
--- a/example/e2e/function.yaml
+++ b/example/e2e/function.yaml
@@ -22,6 +22,6 @@ kind: Function
 metadata:
   name: function-msgraph
 spec:
-  package: xpkg.upbound.io/upbound/function-msgraph:v0.8.0-rc2
+  package: xpkg.upbound.io/upbound/function-msgraph:v0.8.0
   runtimeConfigRef:
     name: msgraph-debug

--- a/example/functions.yaml
+++ b/example/functions.yaml
@@ -7,7 +7,7 @@ metadata:
     # This tells crossplane beta render to connect to the function locally.
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.upbound.io/upbound/function-msgraph:v0.6.0
+  package: xpkg.upbound.io/upbound/function-msgraph:v0.8.0
 ---
 apiVersion: pkg.crossplane.io/v1beta1
 kind: Function


### PR DESCRIPTION
### Description of your changes

Post-release cleanup of two stale `function-msgraph` package pins found while running post-release validation of [v0.8.0](https://marketplace.upbound.io/functions/upbound/function-msgraph/v0.8.0):

| File | Was | Now |
|---|---|---|
| `example/e2e/function.yaml` | `v0.8.0-rc2` | `v0.8.0` |
| `example/functions.yaml` | `v0.6.0` | `v0.8.0` |

The `e2e` one is the release candidate left behind after tagging. Renovate's `crossplane` manager does cover `example/**`, but it is unlikely to move a pin off a pre-release version on its own, so this needed a manual bump.

`function-environment-configs:v0.6.0` in `example/functions.yaml` is deliberately left alone; it shares the `v0.6.0` string but is a separate package.

### How this is covered by tests

No unit tests apply (manifest-only change), so both files were exercised directly against the released artifact.

`example/e2e/function.yaml`, on kind + Crossplane 2.3.3:

- Applies cleanly and reaches `Healthy`, with the installed `FunctionRevision` (`function-msgraph-c18786ca878a`) matching the released image digest `sha256:c18786ca878a...`.
- **queryInterval scenario:** one real Graph query, timestamp recorded in the separate `status.lastQueryTimestamps` field. Five forced reconciles inside the 2m window left Graph calls flat at 1 while `FunctionSkip`/`IntervalLimit` skips incremented and the timestamp stayed frozen. After the window elapsed, the next reconcile re-queried and the timestamp advanced.
- **activeAccount scenario:** baseline stored both users with the disabled one reported as `accountEnabled: false`; the `activeAccount: true` composition stored only the enabled user, logged the per-user exclusion, and held that across further forced reconciles. Both XRs `SYNCED=True READY=True`.
- Function pod: 0 restarts, no errors.

`example/functions.yaml` keeps its `render.crossplane.io/runtime: Development` annotation, so its pin is documentation only and is not what `crossplane render` actually executes. The documented render workflow was re-run through this file against a local build to confirm it still works (3 scenarios, all `FunctionSuccess/Success`).

Separately, all 19 `crossplane render` example scenarios (4 query types x static/status-ref/spec-ref/context-ref, plus the queryInterval fresh/skip and activeAccount cases) were run against the released package with the Development annotation removed. All passed with `FunctionSuccess/Success` and zero non-`Normal` results.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] ~Added or updated unit tests for my change.~ Manifest-only version bump; validated end-to-end against the released package as described above.

[contribution process]: https://git.io/fj2m9